### PR TITLE
For using HTTP-only dashboard add parameter protocolHttp

### DIFF
--- a/stable/kubernetes-dashboard/README.md
+++ b/stable/kubernetes-dashboard/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the kubernetes-dashboar
 | `tolerations`                       | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`                                                                       |
 | `affinity`                          | Affinity for pod assignment                                                                                                 | `[]`                                                                       |
 | `enableSkipLogin`                   | Enable possibility to skip login                                                                                            | `false`                                                                    |
-| `enableInsecureLogin`               | Serve application over HTTP without TLS                                                                                     | `false`                                                                    |
+| `enableInsecureLogin`               | Enable login page to serve over HTTP                                                                                        | `false`                                                                    |
 | `service.externalPort`              | Dashboard external port                                                                                                     | 443                                                                        |
 | `service.internalPort`              | Dashboard internal port                                                                                                     | 443                                                                        |
 | `service.loadBalancerSourceRanges`  | list of IP CIDRs allowed access to load balancer (if supported)                                                             | nil                                                                        |
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the kubernetes-dashboar
 | `podDisruptionBudget.maxUnavailable`| Maximum unavailable instances; ignored if there is no PodDisruptionBudget                                                   |                                                                            |
 | `securityContext`                   | Security context                                                                                                            | `{}`                                                                       |
 | `networkPolicy`                     | Whether to create a network policy that allows access to the service                                                        | `false`                                                                    |
+| `protocolHttp`                      | Serve application over HTTP without TLS                                                                                     | `false`                                                                    | 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/kubernetes-dashboard/templates/NOTES.txt
+++ b/stable/kubernetes-dashboard/templates/NOTES.txt
@@ -5,7 +5,7 @@
 {{- if .Values.ingress.enabled }}
 From outside the cluster, the server URL(s) are:
 {{- range .Values.ingress.hosts }}
-{{- if $.Values.enableInsecureLogin }}
+{{- if $.Values.protocolHttp }}
      http://{{ . }}
 {{- else }}
      https://{{ . }}
@@ -17,7 +17,7 @@ From outside the cluster, the server URL(s) are:
 Get the Kubernetes Dashboard URL by running:
   export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubernetes-dashboard.fullname" . }})
   export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
-{{- if .Values.enableInsecureLogin }}
+{{- if .Values.protocolHttp }}
   echo http://$NODE_IP:$NODE_PORT/
 {{- else }}
   echo https://$NODE_IP:$NODE_PORT/
@@ -30,7 +30,7 @@ Get the Kubernetes Dashboard URL by running:
 
 Get the Kubernetes Dashboard URL by running:
   export SERVICE_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ template "kubernetes-dashboard.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-{{- if .Values.enableInsecureLogin }}
+{{- if .Values.protocolHttp }}
   echo http://$SERVICE_IP/
 {{- else }}
   echo https://$SERVICE_IP/
@@ -39,7 +39,7 @@ Get the Kubernetes Dashboard URL by running:
 
 Get the Kubernetes Dashboard URL by running:
   export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app={{ template "kubernetes-dashboard.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-{{- if .Values.enableInsecureLogin }}
+{{- if .Values.protocolHttp }}
   echo http://127.0.0.1:9090/
   kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 9090:9090
 {{- else }}

--- a/stable/kubernetes-dashboard/templates/deployment.yaml
+++ b/stable/kubernetes-dashboard/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
 {{- end }}
 {{- if .Values.enableInsecureLogin }}
           - --enable-insecure-login
-{{- else }}
+{{- else if not .Values.protocolHttp }}
           - --auto-generate-certificates
 {{- end }}
 {{- if .Values.extraArgs }}
@@ -59,7 +59,7 @@ spec:
 {{ toYaml .Values.extraEnv | indent 10 }}
 {{- end }}
         ports:
-{{- if .Values.enableInsecureLogin }}
+{{- if .Values.protocolHttp }}
         - name: http
           containerPort: 9090
           protocol: TCP
@@ -76,7 +76,7 @@ spec:
           name: tmp-volume
         livenessProbe:
           httpGet:
-{{- if .Values.enableInsecureLogin }}
+{{- if .Values.protocolHttp }}
             scheme: HTTP
             path: /
             port: 9090

--- a/stable/kubernetes-dashboard/templates/svc.yaml
+++ b/stable/kubernetes-dashboard/templates/svc.yaml
@@ -16,7 +16,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   - port: {{ .Values.service.externalPort }}
-{{- if .Values.enableInsecureLogin }}
+{{- if .Values.protocolHttp }}
     targetPort: 9090
     name: "http"
 {{- else }}

--- a/stable/kubernetes-dashboard/values.yaml
+++ b/stable/kubernetes-dashboard/values.yaml
@@ -18,11 +18,13 @@ annotations: {}
 labels: {}
 # kubernetes.io/name: "Kubernetes Dashboard"
 
+## Serve application over HTTP without TLS
+protocolHTTP: false
 
 ## Enable possibility to skip login
 enableSkipLogin: false
 
-## Serve application over HTTP without TLS
+## Enable login page to serve over HTTP
 enableInsecureLogin: false
 
 ## Additional container arguments


### PR DESCRIPTION
See https://github.com/helm/charts/pull/15947.
#### What this PR does / why we need it:
Splitting some functionality from the parameter `enableInsecureLogin` into `protocolHttp`. Before this change the `enableInsecureLogin` parameter also enabled HTTP-only. It was not possible to use HTTP only and disable insecure login. Now; with this new parameter seperated; it is possible to deploy the dashboard with only HTTP without setting `enableInsecureLogin` which result in a dashboard served over HTTP without login prompt.

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
